### PR TITLE
remove python version restriction

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python
+  - python=3.11
   - dask[complete] 
   - dask-jobqueue
   - jupyterlab>=3

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python
   - dask[complete] 
   - dask-jobqueue
   - jupyterlab>=3


### PR DESCRIPTION
When testing [JupyterDaskOnSLURM](https://github.com/RS-DAT/JupyterDaskOnSLURM) with sarxarray, we tested with Python 3.11. Both env creation and execution worked. Therefore it seems we do not need to restrict Python version anymore.