### PR TITLE
added ssh key pass phrase handling'

### DIFF
--- a/runJupyterDaskOnSLURM.py
+++ b/runJupyterDaskOnSLURM.py
@@ -196,7 +196,6 @@ def load_platform_config(uid):
     else:
         pfconfig = config[uid]
         config_inputs = {'platform':pfconfig['platform'], 'host':pfconfig['host'], 'user':pfconfig['user'], 'keypath':pfconfig['keypath'], 'key_pass':pfconfig['key_pass']}
-        print(type(config_inputs['key_pass']))
         return config_inputs, pfconfig['platform']
 
 


### PR DESCRIPTION
This branch implements handling of ssh keys with associated pass phrases.
when using --add-platform the user is requested to specify whether the key associated with the uid has a passphrase. This answer is recorded, but the passphrase IS NOT.

When using --mode run (or any other except --add-platform). The user is queried for the passphrase. This makes use of the getpass library and shouldn't echo the input (caveat: Apparently, if using IDLE or some other non-true terminal input may be echoed. ggetpass does warn of this to the best of my knowledge). The password is saved in memory for the session but subsequently discarded and never serialized. 