### PR TITLE
Extension to Delftblue

### DIFF
--- a/config/dask/config_delftblue.yml
+++ b/config/dask/config_delftblue.yml
@@ -1,0 +1,26 @@
+distributed:
+  dashboard:
+    link: "/proxy/{port}/status"
+labextension:
+  factory:
+    module: 'dask_jobqueue'
+    class: 'SLURMCluster'
+    args: []
+    kwargs: {}
+  default:
+    workers: null 
+    adapt:
+      null
+  initial:
+    - name: 'SLURMCluster'
+jobqueue:
+  slurm:
+    name: dask-worker
+    # uncomment for DelftBlue
+    cores: 1                   # Total number of cores per job. This is for every worker
+    memory: '1GiB'             # Total amount of memory per job
+    queue: 'compute'           # Queue name: 'compute', 'gpu', 'memory`
+    processes: 1               # Number of Python processes per job. Threads on each core
+    death-timeout: 600         # Number of seconds to wait if a worker can not find a scheduler
+    local-directory: '/scratch/$USER'  # Location of fast local storage like /scratch or $TMPDIR
+    walltime: '2:00:00'

--- a/config/dask/config_delftblue.yml
+++ b/config/dask/config_delftblue.yml
@@ -17,7 +17,7 @@ jobqueue:
   slurm:
     name: dask-worker
     # uncomment for DelftBlue
-    cores: 1                   # Total number of cores per job. This is for every worker
+    cores: 2                   # Total number of cores per job. This is for every worker
     memory: '1GiB'             # Total amount of memory per job
     queue: 'compute'           # Queue name: 'compute', 'gpu', 'memory`
     processes: 1               # Number of Python processes per job. Threads on each core

--- a/scripts/jupyter_dask_delftblue.bsh
+++ b/scripts/jupyter_dask_delftblue.bsh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+### Initialize the server
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --time=23:00:00
+#SBATCH --cpus-per-task=4
+#SBATCH --mem-per-cpu=4G
+#SBATCH --partition=compute
+#SBATCH --account=innovation ## replace with research-<faculty>-<department>. This will enable to request more resources.
+
+source ~/.bashrc
+conda activate jupyter_dask
+
+node=`hostname -s`
+port=`shuf -i 8400-9400 -n 1`
+if [ -z ${lport:+x} ]; then lport="8889" ; else lport=${lport}; fi
+
+echo "Run the following on your local machine: "
+echo "ssh -i /path/to/private/ssh/key -N -L ${lport}:${node}:${port} ${USER}@login.delftblue.tudelft.nl"
+
+jupyter lab --no-browser --port=${port} --ip=${node}

--- a/scripts/jupyter_dask_delftblue.bsh
+++ b/scripts/jupyter_dask_delftblue.bsh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 ### Initialize the server
-#SBATCH --nodes=1
+#SBATCH --partition=compute ## one of 'compute', 'gpu', 'memory'
 #SBATCH --ntasks=1
 #SBATCH --time=23:00:00
 #SBATCH --cpus-per-task=4
 #SBATCH --mem-per-cpu=4G
-#SBATCH --partition=compute
 #SBATCH --account=innovation ## replace with research-<faculty>-<department>. This will enable to request more resources.
 
 source ~/.bashrc

--- a/scripts/jupyter_dask_delftblue.bsh
+++ b/scripts/jupyter_dask_delftblue.bsh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 ### Initialize the server
 #SBATCH --partition=compute ## one of 'compute', 'gpu', 'memory'
 #SBATCH --ntasks=1

--- a/user-guide.md
+++ b/user-guide.md
@@ -1,12 +1,33 @@
 # User guide
 
-The following steps will help you to run a Jupyter server and a Dask cluster on one of the SURF systems running SLURM, such as Spider, Snellius or Lisa (please find information on how to get access to SURF infrastructure [here](https://www.surf.nl/en/research-it/apply-for-access-to-compute-services)).
+The following steps will help you to run a Jupyter server and a Dask cluster on one of the SURF systems running SLURM, such as Spider, Snellius or Lisa (please find information on how to get access to SURF infrastructure [here](https://www.surf.nl/en/research-it/apply-for-access-to-compute-services)). Or on the [DelftBlue Supercomputer at TU Delft](https://doc.dhpc.tudelft.nl/delftblue/).
 
-This guide assumes that you have received credentials from SURF, that you are able to access the system via SSH, and that an SSH key pair has been set up for password-less login (see the dedicated SURF guides for [Lisa/Snellius](https://servicedesk.surf.nl/wiki/display/WIKI/SSH#SSH-Bonus2:public-keyauthentication) and [Spider](https://spiderdocs.readthedocs.io/en/latest/Pages/getting_started.html)). 
+This guide assumes that you have received credentials from SURF or TU Delft, that you are able to access the system via SSH, and that an SSH key pair has been set up for password-less login (see the dedicated SURF guides for [Lisa/Snellius](https://servicedesk.surf.nl/wiki/display/WIKI/SSH#SSH-Bonus2:public-keyauthentication), [Spider](https://spiderdocs.readthedocs.io/en/latest/Pages/getting_started.html), and [DelftBlue](https://doc.dhpc.tudelft.nl/delftblue/Remote-access-to-DelftBlue/)). 
 
-## Local Set-up 
+**Contents:**
+- [User guide](#user-guide)
+  - [Local Set-up](#local-set-up)
+    - [Installation on remote host](#installation-on-remote-host)
+      - [Configuring DCache](#configuring-dcache)
+    - [Running](#running)
+  - [Shutting down](#shutting-down)
+  - [Uninstallation on Remote host](#uninstallation-on-remote-host)
+  - [Manual Installation](#manual-installation)
+  - [Configuration](#configuration)
+    - [Jupyter](#jupyter)
+    - [Dask](#dask)
+    - [dCache](#dcache)
+  - [Troubleshooting](#troubleshooting)
+    - [Manual deployment](#manual-deployment)
+  - [Delft Blue](#delft-blue)
+    - [Installation](#installation)
+    - [Configuration](#configuration-1)
+    - [Deployment](#deployment)
 
-This repository includes [a Python script](./scripts/runJupyterDaskOnSLURM.py) to install the components remotely on a SURF platform (Snellius/Spider/etc.) and to start Jupyter and Dask services on this SURF platform from local. 
+## Local Set-up
+
+This repository includes [a Python script](./scripts/runJupyterDaskOnSLURM.py) to install the components remotely on a SURF platform (Snellius/Spider/etc.), and to start Jupyter and Dask services on that platform from a local machine. 
+
 
 **On your local machine**, download the script by cloning this repository:
 ```shell
@@ -26,9 +47,9 @@ python runJupyterDaskOnSLURM.py --add_platform
 
 ### Installation on remote host 
 
-Before installing on the remote host, edit the environment.yaml file in the folder to include all conda/pip packages that are needed to run your proposed workflow.
+Before installing on the remote host, edit the `environment.yaml` file in the folder to include all conda/pip packages that are needed to run your proposed workflow.
 
-After editing the environment.yaml file, installing the components on the remote host can be done on the platform as:
+After editing the `environment.yaml` file, installing the components on the remote host can be done on the platform as:
 ```shell
 python runJupyterDaskOnSLURM.py --uid <PLATFORM_NAME> --mode install
 ```
@@ -154,6 +175,97 @@ sbatch scripts/jupyter_dask.bsh
 Copy the `ssh` command printed in the job stdout (file `slurm-<JOB_ID>.out`). It should look like:
 ```shell
 ssh -i /path/to/private/ssh/key -N -L 8889:NODE:8888 USER@sssssss.surf.nl
+``` 
+
+Paste the command in a new terminal window **on your local machine** (modify the path to the private key). You can now access the Jupyter session from your browser at `localhost:8889`.
+
+
+## Delft Blue
+
+Follow the steps bellow to install and configure 
+
+### Installation
+
+1. Use `module` to load `miniconda`
+```shell
+module load miniconda3/4.12.0
+```
+
+2. Clone the repository:
+```shell
+git clone http://github.com/RS-DAT/JupyterDaskOnSLURM.git 
+cd JupyterDaskOnSLURM
+```
+3. If required, modigy the `environment.yaml` to include relevant packages for your workflow. Then, crate an environment using conda"
+```shell
+conda env create -f environment.yaml
+```
+
+1. Activate the environment and install additional dependencies using `conda`/`pip`, as required by each use case:
+```shell
+conda activate jupyter_dask
+conda install ...
+pip install ...
+```
+
+### Configuration
+
+1. Configure the password to access **Jupyter**:
+```shell
+jupyter server --generate-config
+jupyter server password
+```
+and make the Jupyter config file that is created after running the previous step readable by the current user only:
+```shell
+chmod 400 ~/.jupyter/jupyter_server_config.py 
+```
+
+The repository directory `scripts` contains template job scripts for Spider, Snellius and DelftBlue. These scripts define the requirements of the SLURM job running the Jupyter server, they can be customized depending on the specific user needs.
+
+```shell
+#!/bin/bash
+### Initialize the server
+#SBATCH --partition=compute ## one of 'compute', 'gpu', 'memory'
+#SBATCH --ntasks=1
+#SBATCH --time=23:00:00
+#SBATCH --cpus-per-task=4
+#SBATCH --mem-per-cpu=4G
+#SBATCH --account=innovation ## replace with research-<faculty>-<department>. This will enable to request more resources.
+
+source ~/.bashrc
+conda activate jupyter_dask
+
+node=`hostname -s`
+port=`shuf -i 8400-9400 -n 1`
+if [ -z ${lport:+x} ]; then lport="8889" ; else lport=${lport}; fi
+
+echo "Run the following on your local machine: "
+echo "ssh -i /path/to/private/ssh/key -N -L ${lport}:${node}:${port} ${USER}@login.delftblue.tudelft.nl"
+
+jupyter lab --no-browser --port=${port} --ip=${node}
+```
+
+2. Configure the **Dask** settings. The repository directory `config/dask` contains templates for the Dask configuration files. The cofiguration file defines the default worker settings in the Dask cluster, and it thus **needs to be edited depending on the SURF system or other system** which we are running on. In particular, the  **file corresponding to DelftBlue `config/dask/config_delftblue.yml`**. Copy the file to `${HOME}/.config/dask`:
+```shell
+mkdir -p ~/.config/dask
+cp -r config/dask/config_delftblue.yml ~/.config/dask/config.yml 
+```
+
+The default Dask settings can be further tuned depending on user needs.
+
+### Deployment
+
+On DelftBlue, you need to start the the Jupyter and Dask services manually using this procedure.
+
+1. Login to DelftBlue, then submit a SLURM job based using the template provided in `scripts/jupyter_dask_delftblue.bsh` to start the Jupyter server and the Dask scheduler on the login node: 
+   
+```shell
+sbatch scripts/jupyter_dask_delftblue.bsh
+```
+
+Copy the `ssh` command printed in the job stdout (file `slurm-<JOB_ID>.out`). It should look like:
+```shell
+ssh -i /path/to/private/ssh/key -N -L 8889:NODE:8888 USER@sssssss.tudelft.nl
 ``` 
 
 Paste the command in a new terminal window **on your local machine** (modify the path to the private key). You can now access the Jupyter session from your browser at `localhost:8889`.

--- a/user-guide.md
+++ b/user-guide.md
@@ -196,7 +196,7 @@ module load miniconda3/4.12.0
 git clone http://github.com/RS-DAT/JupyterDaskOnSLURM.git 
 cd JupyterDaskOnSLURM
 ```
-3. If required, modigy the `environment.yaml` to include relevant packages for your workflow. Then, crate an environment using conda"
+3. If required, modify the `environment.yaml` to include relevant packages for your workflow. Then, create an environment using conda"
 ```shell
 conda env create -f environment.yaml
 ```


### PR DESCRIPTION
This PR includes templates and instructions to deploy the Dask Cluster on DelftBlue as recommended by RS-DAT.

- [x] Adds template for SLURM jobs to `scripts/`
- [x] Adds template for configuring Dask workers to `config/dask/`
- [x] Adds ToC to `user-guide.md`
- [x] Adds installation and configuration instructions when using DelftBlue to `user-guide.md`

The templates and configuration files were tested in DelftBlue.

