### PR TITLE
Bash spider containerization

### DIFF
--- a/scripts/jupyter_dask_spider_container.bsh
+++ b/scripts/jupyter_dask_spider_container.bsh
@@ -8,7 +8,7 @@
 source ~/.bashrc
 
 # CHANGE THIS TO THE ABSOLUTE PATH TO THE CONTAINER BIN
-export PATH="/abusolute/path/to/the/container/bin:$PATH"
+export PATH="/absolute/path/to/the/container/bin:$PATH"
 
 node=`hostname -s`
 port=`shuf -i 8400-9400 -n 1`

--- a/spider_container_deploy.sh
+++ b/spider_container_deploy.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+echo "Current working directory is $PWD"
+if [[ ! ./ -ef ~ ]] ; then
+    echo "changing directory to $HOME" 
+    cd $HOME
+fi
+
+#clone the hpc_container_wrapper JupyterDaskOnSLurm repositories
+#tis assumes that git access (ssh key) has been configured on spider by the user
+git clone git@github.com:CSCfi/hpc-container-wrapper.git
+#git clone git@github.com:RS-DAT/JupyterDaskOnSLURM.git
+
+#change directory to the hpc-container-wrapper dir
+cd hpc-container-wrapper
+echo "Current working directory is $PWD"
+
+#copy spider config to hpc-container-wrapper configs
+cp ../JupyterDaskOnSLURM/config/container/spider.yaml ./configs/
+
+#run container wrapper installation
+source install.sh spider
+echo 'completed hpc-container-wrapper install.sh for spider'
+
+echo 'copying environment.yaml from JupyterDaskOnSlurm'
+cp ../JupyterDaskOnSLURM/environment.yaml .
+echo 'creating new containerized environment'
+
+#the hardcoded bash structure of hpc-container-wrapper makes sourced calls to the containerization
+#unfeasible, at least while adhereing to the overall program flow. Similarly the bash scripts also preclude a 
+#more direct call of the relevant routines. The solution below is a interm fix until we decide whether to fork and fix 
+#or create and issue and submit a PR upstream.
+#
+
+containerize_source_file='./frontends/containerize'
+containerize_match="calling_name=\$(basename \$0)"
+containerize_insert="calling_name=\$(basename \${BASH_SOURCE\[0\]})"
+
+sed -i "s@$containerize_match@$containerize_insert@" $containerize_source_file
+
+
+mkdir -p  ./jupyter_dask
+source bin/conda-containerize new --prefix ./jupyter_dask ./environment.yaml
+echo 'complete'
+
+echo 'updating JupyterDaskOnSLurm configuration'
+cd ..
+mkdir -p ~/.config/dask 
+cp JupyterDaskOnSLURM/config/dask/config_spider.yml ~/.config/dask/config.yml
+
+#insert path export statements into configuration files
+#this makes use of `sed`. Note that the  comamnd behaviour of `sed` for inline replacement differs between Linux and MacOs
+#this is handled below
+
+dask_config_file="$HOME/.config/dask/config.yml"
+dask_config_match="walltime: '10:00:00'"
+dask_config_insert="    job_script_prologue:\n    -  'export PATH=\"$_inst_path/bin:\$PATH\" ' \n    python: python\n "
+
+sed -i "s@$dask_config_match@$dask_config_match\n$dask_config_insert@" $dask_config_file
+
+slurm_file="$HOME/JupyterDaskOnSLURM/scripts/jupyter_dask_spider_container.bsh"
+slurm_match="export PATH=\"/absolute/path/to/the/container/bin:\$PATH\""
+slurm_insert="export PATH=\"$_inst_path/bin:\$PATH\""
+
+sed -i "s@$slurm_match@$slurm_insert@" $slurm_file
+
+

--- a/spider_container_deploy.sh
+++ b/spider_container_deploy.sh
@@ -9,7 +9,6 @@ fi
 #clone the hpc_container_wrapper JupyterDaskOnSLurm repositories
 #tis assumes that git access (ssh key) has been configured on spider by the user
 git clone git@github.com:CSCfi/hpc-container-wrapper.git
-#git clone git@github.com:RS-DAT/JupyterDaskOnSLURM.git
 
 #change directory to the hpc-container-wrapper dir
 cd hpc-container-wrapper

--- a/user-guide.md
+++ b/user-guide.md
@@ -256,7 +256,7 @@ bin/conda-containerize new --prefix ./jupyter_dask ./environment.yaml
 At the end of the installation, the tool will print the path to the executable directory (`bin` directory) of the container. For example:
 
 ```output
-export PATH="/abusolute/path/to/the/container/bin:$PATH" 
+export PATH="/absolute/path/to/the/container/bin:$PATH" 
 ```
 
 ```shell
@@ -269,7 +269,7 @@ Then add the following lines to the `~/.config/dask/config.yml` file, under the 
 
 ```yaml
     job_script_prologue:
-      - 'export PATH="/abusolute/path/to/the/container/bin:$PATH"' # Export environment path to
+      - 'export PATH="/absolute/path/to/the/container/bin:$PATH"' # Export environment path to
     python: python
 ```
 
@@ -292,7 +292,7 @@ Then also configure the SLURM job file `JupyterDaskOnSLURM/scripts/jupyter_dask_
 
 ```shell
 # CHANGE THIS TO THE ABSOLUTE PATH TO THE CONTAINER BIN
-export PATH="/abusolute/path/to/the/container/bin:$PATH"
+export PATH="/absolute/path/to/the/container/bin:$PATH"
 ```
 
 Now you have reached the exit point of the deployment script and are all set!

--- a/user-guide.md
+++ b/user-guide.md
@@ -195,7 +195,37 @@ We assume you are in the home directory. If not, change to the home directory:
 cd ~
 ```
 
-Then, clone the `hpc-container-wrapper` and `JupyterDaskOnSLURM` repositories:
+Then, clone the `JupyterDaskOnSLURM` repository:
+```shell
+git clone git@github.com:RS-DAT/JupyterDaskOnSLURM.git
+```
+
+change to the `JupyterDaskOnSLURM` directory:
+
+```shell
+cd JupyterDaskOnSLURM
+```
+
+and execute the `spider_container_deploy.sh` script:
+
+```shell
+bash spider_container_deploy.sh
+```
+
+This will run the setup and containerization of the `environment.yaml` file contained in the `JupyterDaskOnSLURM` directory (please modify as needed before running the script).
+
+Now you are all set! 
+
+### manual installation
+Should yopu prefer to manually set up the containerization please follow the steps below, which are otherwise handled by the script.
+
+First change to your home directory:
+
+```shell
+cd ~
+```
+
+Then, assuming you haven't already cloned the `JupyterDaskOnSLURM` repository, clone both the `hpc-container-wrapper` and `JupyterDaskOnSLURM` repositories:
 
 ```shell
 git clone git@github.com:CSCfi/hpc-container-wrapper.git
@@ -218,6 +248,7 @@ bash install.sh spider
 Next, copy the `environment.yaml` file from the `JupyterDaskOnSLURM` repository to the current directory and create a container. In the following example, we create a container under `jupyter_dask` directory:
 
 ```shell
+mkdir -p ./jupyter_dask
 cp ../JupyterDaskOnSLURM/environment.yaml .
 bin/conda-containerize new --prefix ./jupyter_dask ./environment.yaml
 ```
@@ -264,7 +295,10 @@ Then also configure the SLURM job file `JupyterDaskOnSLURM/scripts/jupyter_dask_
 export PATH="/abusolute/path/to/the/container/bin:$PATH"
 ```
 
-Now you are all set! The Jupyter Server with Dask plugin and be started using the `jupyter_dask_spider_container.bsh` script.
+Now you have reached the exit point of the deployment script and are all set!
+
+## Starting the Jupyter Server and Dask plugin
+The Jupyter Server with Dask plugin and can now be started using the `jupyter_dask_spider_container.bsh` script.
 
 ```shell
 sbatch JupyterDaskOnSLURM/scripts/jupyter_dask_spider_container.bsh


### PR DESCRIPTION
provides bash install/containerization for spider hiding setup from users. Completes #69 

execute as `bash spider_container_deploy.sh` 

Note: Users are now first required to manually clone JupyterDaskOnSlurm in order to have access to the script. This is reflected in the updated user guide.



 