### PR TITLE
Update spider_container_deploy.sh

### DIFF
--- a/spider_container_deploy.sh
+++ b/spider_container_deploy.sh
@@ -8,7 +8,8 @@ fi
 
 #clone the hpc_container_wrapper JupyterDaskOnSLurm repositories
 #tis assumes that git access (ssh key) has been configured on spider by the user
-git clone git@github.com:CSCfi/hpc-container-wrapper.git
+#git clone git@github.com:CSCfi/hpc-container-wrapper.git
+git clone https://github.com/CSCfi/hpc-container-wrapper.git
 
 #change directory to the hpc-container-wrapper dir
 cd hpc-container-wrapper


### PR DESCRIPTION
I encountered also an issue with the $_inst_path variable while working with spider_container_deploy.sh. The script didn't correctly pick up the $_inst_path, resulting in it being empty.

To resolve this, I manually updated the following files as indicated in your documentation.:

~/.config/dask/config.yml
JupyterDaskOnSLURM/scripts/jupyter_dask_spider_container.bsh
After these updates, everything worked correctly.


Thank you.
